### PR TITLE
too many arguments used for mstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,7 @@ object "FullyYul" {
     object "runtime" {
         code {
             // returns the "Message" data
-            mstore(0x00, dataoffset("Message"), datasize("Message"))
+            datacopy(0x00, dataoffset("Message"), datasize("Message"))
             return (0x00, datasize("Message"))
         }
 


### PR DESCRIPTION
this was probably overlooked, and mstore used instead of the correct opcode